### PR TITLE
Fix security issues (Procfile added gunicorn as safe fix)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python manage.py runserver 0.0.0.0:$PORT --noreload
+web: python manage.py run_gunicorn --preload -b 0.0.0.0:$PORT -t 90

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==1.4.3
 dj-database-url==0.2.1
 psycopg2==2.4.5
+gunicorn==0.17.0

--- a/settings.py
+++ b/settings.py
@@ -106,10 +106,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    # Uncomment the next line to enable the admin:
-    # 'django.contrib.admin',
-    # Uncomment the next line to enable admin documentation:
-    # 'django.contrib.admindocs',
+    "gunicorn",
 )
 
 # A sample logging configuration. The only tangible logging


### PR DESCRIPTION
You shouldn't use runserver in production:
https://docs.djangoproject.com/en/1.4/ref/django-admin/#runserver-port-or-address-port

As documentation state I quote:
"DO NOT USE THIS SERVER IN A PRODUCTION SETTING. It has not gone through security audits or performance tests. (And that's how it's gonna stay. We're in the business of making Web frameworks, not Web servers, so improving this server to be able to handle a production environment is outside the scope of Django.)"
