### PR TITLE
Don't display the number of votes a talk has

### DIFF
--- a/templates/vote.html
+++ b/templates/vote.html
@@ -35,7 +35,7 @@
 		{% for entry in entries %}
 
 			<div class="entry" data-id="{{ entry.id }}" id="entry{{ entry.id }}">
-				<div class="baloon_counter">{{ entry.score }}</div>
+				<div class="baloon_counter">???</div>
 
 				<h4>{{ entry.topic }} <a href="/vote/#entry{{ entry.id }}"><i class="icon-link"></i></a></h4>
 


### PR DESCRIPTION
One of the key elements of blind voting is hiding popularity. Popularity effects how people vote for things. In order to have a true blind voting system, people should not be able to see the current scores.
