### PR TITLE
Fix typo on vote page

### DIFF
--- a/templates/vote.html
+++ b/templates/vote.html
@@ -16,7 +16,7 @@
 
 				<b>This round of voting closes on January 19th</b>. There is one important thing: we'll have another round of internal voting then. We already described it in <a href="http://blog.djangocircus.com/post/36590674298/call-for-speakers">Call for Papers rules</a>. In the second round we'll limit the number of options to the first 20-25 voted by you and ask more experienced DjangoCon organizers as well as Django community members to choose the final talks. We will also de-anonymise talks then.<br /><br />
 
-				In order to vote, please indentify yourself by signing in with your Github account.<br /><br />
+				In order to vote, please identify yourself by signing in with your Github account.<br /><br />
 
 				<b>Until now {{ users }} people voted {{ votes }} times.</b><br /><br />
 


### PR DESCRIPTION
"identify" was misspelled as "indentify".
